### PR TITLE
ESP able to reply with the list of exported USB devices.

### DIFF
--- a/firmware/main/include/global.h
+++ b/firmware/main/include/global.h
@@ -12,8 +12,6 @@ extern TaskHandle_t *tcp_server_task;
 extern TaskHandle_t *usb_daemon_task_hdl;
 extern TaskHandle_t *usb_class_driver_task_hdl;
 
-extern SemaphoreHandle_t signaling_sem;
-
 extern struct class_driver_t driver_obj;
 
 #endif

--- a/firmware/main/include/global.h
+++ b/firmware/main/include/global.h
@@ -14,4 +14,7 @@ extern TaskHandle_t *usb_class_driver_task_hdl;
 
 extern struct class_driver_t driver_obj;
 
+/* This variable is used to determine whether the USB device is bind to any of the network */
+extern bool device_busy;
+
 #endif

--- a/firmware/main/include/global.h
+++ b/firmware/main/include/global.h
@@ -1,0 +1,19 @@
+#ifndef __GLOBAL_H__
+#define __GLOBAL_H__
+
+#include <stdio.h>
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+
+#include "usb_handler.h"
+#include "usbip_server.h"
+
+extern TaskHandle_t *tcp_server_task;
+extern TaskHandle_t *usb_daemon_task_hdl;
+extern TaskHandle_t *usb_class_driver_task_hdl;
+
+extern SemaphoreHandle_t signaling_sem;
+
+extern struct class_driver_t driver_obj;
+
+#endif

--- a/firmware/main/include/tcp_connect.h
+++ b/firmware/main/include/tcp_connect.h
@@ -17,6 +17,9 @@
 #include "lwip/sockets.h"
 #include "lwip/sys.h"
 #include <lwip/netdb.h>
+#include <arpa/inet.h>
+
+#include "usb_handler.h"
 
 #define PORT                        3240
 #define KEEPALIVE_IDLE              100

--- a/firmware/main/include/usb_handler.h
+++ b/firmware/main/include/usb_handler.h
@@ -27,9 +27,12 @@ typedef struct
 void usb_host_lib_daemon_task(void *arg);
 void usb_class_driver_task(void *arg);
 
-typedef struct op_rep_devlist_t op_rep_devlist_t;
+typedef struct op_rep_devlist_t op_rep_devlist;
+
+/* Pointer for struct op_rep_devlist_t*/
+op_rep_devlist *dev;
 
 /* Fills the ope_rep_devlist_t struct with the required information */
-esp_err_t get_op_rep_devlist(op_rep_devlist_t *dev);
+void get_op_rep_devlist_function(op_rep_devlist *dev);
 
 #endif

--- a/firmware/main/include/usb_handler.h
+++ b/firmware/main/include/usb_handler.h
@@ -30,9 +30,6 @@ void usb_class_driver_task(void *arg);
 typedef struct op_rep_devlist_t op_rep_devlist;
 typedef struct op_req_devlist_t op_req_devlist;
 
-/* Pointer for struct op_rep_devlist_t*/
-op_rep_devlist *dev;
-
 /* Fills the ope_rep_devlist_t struct with the required information */
 void get_op_rep_devlist_function(op_rep_devlist *dev);
 

--- a/firmware/main/include/usb_handler.h
+++ b/firmware/main/include/usb_handler.h
@@ -5,6 +5,7 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "freertos/semphr.h"
+#include "usbip_server.h"
 #include "esp_log.h"
 #include "esp_err.h"
 #include "esp_intr_alloc.h"
@@ -25,6 +26,8 @@ typedef struct
 /* This function will keep checking for USB Devices */
 void usb_host_lib_daemon_task(void *arg);
 void usb_class_driver_task(void *arg);
+
+typedef struct op_rep_devlist_t op_rep_devlist_t;
 
 /* Fills the ope_rep_devlist_t struct with the required information */
 esp_err_t get_op_rep_devlist(op_rep_devlist_t *dev);

--- a/firmware/main/include/usb_handler.h
+++ b/firmware/main/include/usb_handler.h
@@ -28,6 +28,7 @@ void usb_host_lib_daemon_task(void *arg);
 void usb_class_driver_task(void *arg);
 
 typedef struct op_rep_devlist_t op_rep_devlist;
+typedef struct op_req_devlist_t op_req_devlist;
 
 /* Pointer for struct op_rep_devlist_t*/
 op_rep_devlist *dev;

--- a/firmware/main/include/usb_handler.h
+++ b/firmware/main/include/usb_handler.h
@@ -5,15 +5,12 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "freertos/semphr.h"
-#include "usbip_server.h"
 #include "esp_log.h"
 #include "esp_err.h"
 #include "esp_intr_alloc.h"
 #include "usb/usb_host.h"
 
-#include "tcp_connect.h"
 #include "usbip_server.h"
-#include "global.h"
 
 typedef struct
 {
@@ -28,9 +25,12 @@ void usb_host_lib_daemon_task(void *arg);
 void usb_class_driver_task(void *arg);
 
 typedef struct op_rep_devlist_t op_rep_devlist;
-typedef struct op_req_devlist_t op_req_devlist;
+typedef struct op_rep_import_t op_rep_import;
 
-/* Fills the ope_rep_devlist_t struct with the required information */
-void get_op_rep_devlist_function(op_rep_devlist *dev);
+/* Fills the op_rep_devlist struct with the required information */
+void get_op_rep_devlist(op_rep_devlist *dev);
+
+/* Fills the op_rep_import struct with the required information */
+void get_op_rep_import(op_rep_import *dev);
 
 #endif

--- a/firmware/main/include/usb_handler.h
+++ b/firmware/main/include/usb_handler.h
@@ -10,6 +10,23 @@
 #include "esp_intr_alloc.h"
 #include "usb/usb_host.h"
 
-/* This file will deal with everything with regards to USB handling */
+#include "tcp_connect.h"
+#include "usbip_server.h"
+#include "global.h"
+
+typedef struct
+{
+    usb_host_client_handle_t client_hdl;
+    uint8_t dev_addr;
+    usb_device_handle_t dev_hdl;
+    uint32_t actions;
+} class_driver_t;
+
+/* This function will keep checking for USB Devices */
+void usb_host_lib_daemon_task(void *arg);
+void usb_class_driver_task(void *arg);
+
+/* Fills the ope_rep_devlist_t struct with the required information */
+esp_err_t get_op_rep_devlist(op_rep_devlist_t *dev);
 
 #endif

--- a/firmware/main/include/usbip_server.h
+++ b/firmware/main/include/usbip_server.h
@@ -12,11 +12,20 @@
 #include "usb/usb_host.h"
 
 #include "tcp_connect.h"
+#include "usb_handler.h"
+#include "global.h"
 
 #define USBIP_VERSION 0x0111
 #define BUS_ID "3-2"
 
 typedef struct
+{
+    uint16_t usbip_version;
+    uint16_t command_code;
+    uint32_t status;
+} op_req_devlist_t;
+
+typedef struct op_rep_devlist_t
 {
     uint16_t usbip_version;
     uint16_t reply_code;
@@ -56,7 +65,7 @@ typedef struct
     uint16_t usbip_version;
     uint32_t command_code;
     uint32_t status;
-    char bus_id[32]; 
+    char bus_id[32];
 } op_req_import_t;
 
 typedef struct
@@ -102,9 +111,9 @@ typedef struct
     uint32_t error_count;
 } usbip_ret_submit_t;
 
-typedef struct 
+typedef struct
 {
-   uint32_t unlink_seqnum;
+    uint32_t unlink_seqnum;
 } usbip_cmd_unlink_t;
 
 typedef struct
@@ -112,6 +121,10 @@ typedef struct
     uint32_t status;
 } usbip_ret_unlink_t;
 
+/* Initialise USB/IP Server */
 esp_err_t usbip_server_init();
+
+/* Stop the USB/IP Server and deletes all the tasks */
+esp_err_t usbip_server_stop();
 
 #endif

--- a/firmware/main/include/usbip_server.h
+++ b/firmware/main/include/usbip_server.h
@@ -18,12 +18,12 @@
 #define USBIP_VERSION 0x0111
 #define BUS_ID "3-2"
 
-typedef struct
+typedef struct op_req_devlist_t
 {
     uint16_t usbip_version;
     uint16_t command_code;
     uint32_t status;
-} op_req_devlist_t;
+} __attribute__((packed));
 
 typedef struct op_rep_devlist_t
 {
@@ -49,26 +49,26 @@ typedef struct op_rep_devlist_t
     uint8_t b_interface_sub_class;
     uint8_t b_interface_protocol;
     uint8_t padding;
-} op_rep_devlist_t;
+} __attribute__((packed));
 
-typedef struct
+typedef struct usbip_header_basic_t
 {
     uint32_t command;
     uint32_t seqnum;
     uint32_t devid;
     uint32_t direction;
     uint32_t ep;
-} usbip_header_basic_t;
+} __attribute__((packed));
 
-typedef struct
+typedef struct op_req_import_t
 {
     uint16_t usbip_version;
     uint32_t command_code;
     uint32_t status;
     char bus_id[32];
-} op_req_import_t;
+} __attribute__((packed));
 
-typedef struct
+typedef struct op_rep_import_t
 {
     uint16_t usbip_version;
     uint32_t reply_code;
@@ -88,9 +88,9 @@ typedef struct
     uint8_t b_num_configurations;
     uint8_t b_num_interfaces;
 
-} op_rep_import_t;
+} __attribute__((packed));
 
-typedef struct
+typedef struct usbip_cmd_submit_t
 {
     uint32_t transfer_flags;
     uint32_t transfer_buffer_length;
@@ -100,26 +100,26 @@ typedef struct
     uint32_t interval;
 
     unsigned char setup[8];
-} usbip_cmd_submit_t;
+} __attribute__((packed));
 
-typedef struct
+typedef struct usbip_ret_submit_t
 {
     uint32_t status;
     uint32_t actual_length;
     uint32_t start_frame;
     uint32_t number_of_packets;
     uint32_t error_count;
-} usbip_ret_submit_t;
+} __attribute__((packed));
 
-typedef struct
+typedef struct usbip_cmd_unlink_t
 {
     uint32_t unlink_seqnum;
-} usbip_cmd_unlink_t;
+} __attribute__((packed));
 
-typedef struct
+typedef struct usbip_ret_unlink_t
 {
     uint32_t status;
-} usbip_ret_unlink_t;
+} __attribute__((packed));
 
 /* Initialise USB/IP Server */
 esp_err_t usbip_server_init();

--- a/firmware/main/include/usbip_server.h
+++ b/firmware/main/include/usbip_server.h
@@ -18,12 +18,24 @@
 #define USBIP_VERSION 0x0111
 #define BUS_ID "3-2"
 
+/* Command code */
+#define OP_REQ_DEVLIST 0x8005
+#define OP_REQ_IMPORT 0x8003
+#define USBIP_CMD_SUBMIT 0x00000001
+#define USBIP_RET_SUBMIT 0x00000003
+#define USBIP_CMD_UNLINK 0x00000002
+#define USBIP_RET_UNLINK 0x00000004
+
+/* Reply Code */
+#define OP_REP_DEVLIST 0x0005
+#define OP_REP_IMPORT 0x0003
+
 typedef struct op_req_devlist_t
 {
     uint16_t usbip_version;
     uint16_t command_code;
     uint32_t status;
-} __attribute__((packed));
+} __attribute__((packed)) op_req_devlist;
 
 typedef struct op_rep_devlist_t
 {
@@ -49,7 +61,7 @@ typedef struct op_rep_devlist_t
     uint8_t b_interface_sub_class;
     uint8_t b_interface_protocol;
     uint8_t padding;
-} __attribute__((packed));
+} __attribute__((packed)) op_rep_devlist;
 
 typedef struct usbip_header_basic_t
 {
@@ -58,7 +70,7 @@ typedef struct usbip_header_basic_t
     uint32_t devid;
     uint32_t direction;
     uint32_t ep;
-} __attribute__((packed));
+} __attribute__((packed)) usbip_header_basic;
 
 typedef struct op_req_import_t
 {
@@ -66,12 +78,12 @@ typedef struct op_req_import_t
     uint32_t command_code;
     uint32_t status;
     char bus_id[32];
-} __attribute__((packed));
+} __attribute__((packed)) op_req_import;
 
 typedef struct op_rep_import_t
 {
     uint16_t usbip_version;
-    uint32_t reply_code;
+    uint16_t reply_code;
     uint32_t status;
     char path[256];
     char bus_id[32];
@@ -88,7 +100,7 @@ typedef struct op_rep_import_t
     uint8_t b_num_configurations;
     uint8_t b_num_interfaces;
 
-} __attribute__((packed));
+} __attribute__((packed)) op_rep_import;
 
 typedef struct usbip_cmd_submit_t
 {
@@ -100,7 +112,7 @@ typedef struct usbip_cmd_submit_t
     uint32_t interval;
 
     unsigned char setup[8];
-} __attribute__((packed));
+} __attribute__((packed)) usbip_cmd_submit;
 
 typedef struct usbip_ret_submit_t
 {
@@ -109,17 +121,17 @@ typedef struct usbip_ret_submit_t
     uint32_t start_frame;
     uint32_t number_of_packets;
     uint32_t error_count;
-} __attribute__((packed));
+} __attribute__((packed)) usbip_ret_submit;
 
 typedef struct usbip_cmd_unlink_t
 {
     uint32_t unlink_seqnum;
-} __attribute__((packed));
+} __attribute__((packed)) usbip_cmd_unlink;
 
 typedef struct usbip_ret_unlink_t
 {
     uint32_t status;
-} __attribute__((packed));
+} __attribute__((packed)) usbip_ret_unlink;
 
 /* Initialise USB/IP Server */
 esp_err_t usbip_server_init();

--- a/firmware/main/src/main.c
+++ b/firmware/main/src/main.c
@@ -1,7 +1,7 @@
 #include "usbip_server.h"
-
 int app_main(void)
 {
+    tcp_server_init();
     usbip_server_init();
     return 0;
 }

--- a/firmware/main/src/tcp_connect.c
+++ b/firmware/main/src/tcp_connect.c
@@ -2,10 +2,6 @@
 
 #define TAG "TCP_CONNECT"
 
-op_rep_devlist *dev_tcp;
-
-op_req_devlist dev_recv;
-
 esp_err_t tcp_server_init(void)
 {
     ESP_ERROR_CHECK(nvs_flash_init());
@@ -19,7 +15,7 @@ esp_err_t tcp_server_init(void)
 static void do_recv(const int sock)
 {
     int len;
-
+    op_req_devlist dev_recv;
     len = recv(sock, &dev_recv, sizeof(struct op_req_devlist_t), 0);
     if (len < 0)
     {
@@ -34,6 +30,7 @@ static void do_recv(const int sock)
         printf("USBIP Version: %u\n", ntohs(dev_recv.usbip_version));
         printf("Command Code: %u\n", ntohs(dev_recv.command_code));
         printf("Status: %u\n", ntohl(dev_recv.status));
+        op_rep_devlist dev_tcp;
         if (ntohs(dev_recv.command_code) == 0x8005)
         {
             get_op_rep_devlist_function(&dev_tcp);

--- a/firmware/main/src/usb_handler.c
+++ b/firmware/main/src/usb_handler.c
@@ -1,1 +1,282 @@
 #include "usb_handler.h"
+#include "usbip_server.h"
+
+#define CLIENT_NUM_EVENT_MSG 5
+
+#define ACTION_OPEN_DEV 0x01
+#define ACTION_GET_DEV_INFO 0x02
+#define ACTION_GET_DEV_DESC 0x04
+#define ACTION_GET_CONFIG_DESC 0x08
+#define ACTION_GET_STR_DESC 0x10
+#define ACTION_CLOSE_DEV 0x20
+#define ACTION_EXIT 0x40
+
+#define TAG "USB_HANDLER"
+
+TaskHandle_t *usb_class_driver_task_hdl = NULL;
+TaskHandle_t *usb_daemon_task_hdl = NULL;
+
+static usb_device_info_t dev_info;
+static const usb_device_desc_t *dev_desc;
+static const usb_config_desc_t *config_desc;
+static const usb_intf_desc_t *interface_desc;
+
+SemaphoreHandle_t signaling_sem;
+
+static void client_event_cb(const usb_host_client_event_msg_t *event_msg, void *arg)
+{
+    class_driver_t *driver_obj = (class_driver_t *)arg;
+    switch (event_msg->event)
+    {
+    case USB_HOST_CLIENT_EVENT_NEW_DEV:
+        if (driver_obj->dev_addr == 0)
+        {
+            driver_obj->dev_addr = event_msg->new_dev.address;
+            // Open the device next
+            driver_obj->actions |= ACTION_OPEN_DEV;
+        }
+        break;
+    case USB_HOST_CLIENT_EVENT_DEV_GONE:
+        if (driver_obj->dev_hdl != NULL)
+        {
+            // Cancel any other actions and close the device next
+            driver_obj->actions = ACTION_CLOSE_DEV;
+        }
+        break;
+    default:
+        // Should never occur
+        abort();
+    }
+}
+
+static void action_open_dev(class_driver_t *driver_obj)
+{
+    assert(driver_obj->dev_addr != 0);
+    ESP_LOGI(TAG, "Opening device at address %d", driver_obj->dev_addr);
+    ESP_ERROR_CHECK(usb_host_device_open(driver_obj->client_hdl, driver_obj->dev_addr, &driver_obj->dev_hdl));
+    // Get the device's information next
+    driver_obj->actions &= ~ACTION_OPEN_DEV;
+    driver_obj->actions |= ACTION_GET_DEV_INFO;
+}
+
+static void action_get_info(class_driver_t *driver_obj)
+{
+    assert(driver_obj->dev_hdl != NULL);
+    ESP_LOGI(TAG, "Getting device information");
+    // usb_device_info_t dev_info;
+    ESP_ERROR_CHECK(usb_host_device_info(driver_obj->dev_hdl, &dev_info));
+    ESP_LOGI(TAG, "\t%s speed", (dev_info.speed == USB_SPEED_LOW) ? "Low" : "Full");
+    ESP_LOGI(TAG, "\tbConfigurationValue %d", dev_info.bConfigurationValue);
+
+    // Get the device descriptor next
+    driver_obj->actions &= ~ACTION_GET_DEV_INFO;
+    driver_obj->actions |= ACTION_GET_DEV_DESC;
+}
+
+static void action_get_dev_desc(class_driver_t *driver_obj)
+{
+    assert(driver_obj->dev_hdl != NULL);
+    ESP_LOGI(TAG, "Getting device descriptor");
+    // const usb_device_desc_t *dev_desc;
+    ESP_ERROR_CHECK(usb_host_get_device_descriptor(driver_obj->dev_hdl, &dev_desc));
+    usb_print_device_descriptor(dev_desc);
+    // Get the device's config descriptor next
+    driver_obj->actions &= ~ACTION_GET_DEV_DESC;
+    driver_obj->actions |= ACTION_GET_CONFIG_DESC;
+}
+
+static void action_get_config_desc(class_driver_t *driver_obj)
+{
+    assert(driver_obj->dev_hdl != NULL);
+    ESP_LOGI(TAG, "Getting config descriptor");
+    // const usb_config_desc_t *config_desc;
+    ESP_ERROR_CHECK(usb_host_get_active_config_descriptor(driver_obj->dev_hdl, &config_desc));
+    usb_print_config_descriptor(config_desc, NULL);
+    // Get the device's string descriptors next
+    driver_obj->actions &= ~ACTION_GET_CONFIG_DESC;
+    driver_obj->actions |= ACTION_GET_STR_DESC;
+}
+
+static void action_get_str_desc(class_driver_t *driver_obj)
+{
+    assert(driver_obj->dev_hdl != NULL);
+    // usb_device_info_t dev_info;
+    // ESP_ERROR_CHECK(usb_host_device_info(driver_obj->dev_hdl, &dev_info));
+    if (dev_info.str_desc_manufacturer)
+    {
+        ESP_LOGI(TAG, "Getting Manufacturer string descriptor");
+    }
+    if (dev_info.str_desc_product)
+    {
+        ESP_LOGI(TAG, "Getting Product string descriptor");
+    }
+    if (dev_info.str_desc_serial_num)
+    {
+        ESP_LOGI(TAG, "Getting Serial Number string descriptor");
+    }
+    // Nothing to do until the device disconnects
+    int offset;
+    interface_desc = usb_parse_interface_descriptor(config_desc, 0, usb_parse_interface_number_of_alternate(config_desc, 0), &offset);
+    driver_obj->actions &= ~ACTION_GET_STR_DESC;
+}
+
+static void aciton_close_dev(class_driver_t *driver_obj)
+{
+    ESP_ERROR_CHECK(usb_host_device_close(driver_obj->client_hdl, driver_obj->dev_hdl));
+    driver_obj->dev_hdl = NULL;
+    driver_obj->dev_addr = 0;
+    // We need to exit the event handler loop
+    driver_obj->actions &= ~ACTION_CLOSE_DEV;
+    driver_obj->actions |= ACTION_EXIT;
+}
+
+/* Fills the dev struct with all the required information */
+esp_err_t get_op_rep_devlist(op_rep_devlist_t *dev)
+{
+    dev->usbip_version = USBIP_VERSION;
+    dev->reply_code = 0x0005;
+    dev->status = 0x00000000;
+    dev->no_of_device = 0x00000001;
+    strcpy(dev->path, "/sys/devices/pci0000:00/0000:00:1d.1/usb2/3-2");
+    strcpy(dev->bus_id, BUS_ID);
+
+    /* Not sure about these */
+    dev->busnum = 1;
+    dev->devnum = 1;
+
+    dev->speed = dev_info.speed;
+    dev->id_vendor = dev_desc->idVendor;
+    dev->id_product = dev_desc->idProduct;
+    dev->bcd_device = dev_desc->bcdDevice;
+    dev->b_device_class = dev_desc->bDeviceClass;
+    dev->b_device_sub_class = dev_desc->bDeviceSubClass;
+    dev->b_device_protocol = dev_desc->bDeviceProtocol;
+    dev->b_configuration_value = dev_info.bConfigurationValue;
+    dev->b_num_configurations = dev_desc->bNumConfigurations;
+    dev->b_num_interfaces = config_desc->bNumInterfaces;
+    dev->b_interface_class = interface_desc->bInterfaceClass;
+    dev->b_interface_sub_class = interface_desc->bInterfaceSubClass;
+    dev->b_interface_protocol = interface_desc->bInterfaceProtocol;
+    dev->padding = 0x00;
+
+    return ESP_OK;
+}
+
+void usb_class_driver_task(void *arg)
+{
+    /* Stores all the information with regards to the USB */
+    class_driver_t driver_obj;
+    while (1)
+    {
+        memset(&driver_obj, 0, sizeof(class_driver_t));
+
+        // Wait until daemon task has installed USB Host Library
+        xSemaphoreTake(signaling_sem, portMAX_DELAY);
+
+        ESP_LOGI(TAG, "Registering Client");
+        usb_host_client_config_t client_config = {
+            .is_synchronous = false, // Synchronous clients currently not supported. Set this to false
+            .max_num_event_msg = CLIENT_NUM_EVENT_MSG,
+            .async = {
+                .client_event_callback = client_event_cb,
+                .callback_arg = (void *)&driver_obj,
+            },
+        };
+        ESP_ERROR_CHECK(usb_host_client_register(&client_config, &driver_obj.client_hdl));
+
+        while (1)
+        {
+            if (driver_obj.actions == 0)
+            {
+                usb_host_client_handle_events(driver_obj.client_hdl, portMAX_DELAY);
+            }
+            else
+            {
+                /* Starting the TCP server on Device Detection */
+                xTaskCreate(tcp_server_start, "TCP Server Start", 4096, NULL, 5, tcp_server_task);
+                vTaskDelay(10);
+
+                if (driver_obj.actions & ACTION_OPEN_DEV)
+                {
+                    action_open_dev(&driver_obj);
+                }
+                if (driver_obj.actions & ACTION_GET_DEV_INFO)
+                {
+                    action_get_info(&driver_obj);
+                }
+                if (driver_obj.actions & ACTION_GET_DEV_DESC)
+                {
+                    action_get_dev_desc(&driver_obj);
+                }
+                if (driver_obj.actions & ACTION_GET_CONFIG_DESC)
+                {
+                    action_get_config_desc(&driver_obj);
+                }
+                if (driver_obj.actions & ACTION_GET_STR_DESC)
+                {
+                    action_get_str_desc(&driver_obj);
+                }
+                if (driver_obj.actions & ACTION_CLOSE_DEV)
+                {
+                    aciton_close_dev(&driver_obj);
+                }
+                if (driver_obj.actions & ACTION_EXIT)
+                {
+                    /* TODO : Unbind the tcp socket and close the socket to prevent any error on client pc */
+                    /* TODO : Delete the TCP SERVER TASK and free up the resource */
+                    break;
+                }
+            }
+        }
+
+        ESP_LOGI(TAG, "Deregistering Client");
+        ESP_ERROR_CHECK(usb_host_client_deregister(driver_obj.client_hdl));
+        xSemaphoreGive(signaling_sem);
+        vTaskDelay(10);
+    }
+}
+
+void usb_host_lib_daemon_task(void *arg)
+{
+    SemaphoreHandle_t signaling_sem = xSemaphoreCreateBinary();
+    /* This will keep on looking for USB Devices */
+    while (1)
+    {
+        ESP_LOGI(TAG, "Installing USB Host Library");
+        usb_host_config_t host_config = {
+            .skip_phy_setup = false,
+            .intr_flags = ESP_INTR_FLAG_LEVEL1,
+        };
+        ESP_ERROR_CHECK(usb_host_install(&host_config));
+
+        // Signal to the class driver task that the host library is installed
+        xSemaphoreGive(signaling_sem);
+        vTaskDelay(10); // Short delay to let client task spin up
+
+        bool has_clients = true;
+        bool has_devices = true;
+
+        /* This loop will continue till the USB Device is connected */
+        while (has_clients || has_devices)
+        {
+            uint32_t event_flags;
+            ESP_ERROR_CHECK(usb_host_lib_handle_events(portMAX_DELAY, &event_flags));
+            if (event_flags & USB_HOST_LIB_EVENT_FLAGS_NO_CLIENTS)
+            {
+                has_clients = false;
+            }
+            if (event_flags & USB_HOST_LIB_EVENT_FLAGS_ALL_FREE)
+            {
+                has_devices = false;
+            }
+        }
+        /* After USB Device is disconnected we need to free the resources */
+        ESP_LOGI(TAG, "No more clients and devices");
+
+        // Uninstall the USB Host Library
+        ESP_ERROR_CHECK(usb_host_uninstall());
+
+        xSemaphoreTake(signaling_sem, portMAX_DELAY);
+        vTaskDelay(10);
+    }
+}

--- a/firmware/main/src/usb_handler.c
+++ b/firmware/main/src/usb_handler.c
@@ -131,21 +131,21 @@ static void aciton_close_dev(class_driver_t *driver_obj)
 /* Fills the dev struct with all the required information */
 void get_op_rep_devlist_function(op_rep_devlist *dev)
 {
-    dev->usbip_version = USBIP_VERSION;
-    dev->reply_code = 0x0005;
-    dev->status = 0x00000000;
-    dev->no_of_device = 0x00000001;
+    dev->usbip_version = htons(USBIP_VERSION);
+    dev->reply_code = htons(0x0005);
+    dev->status = htonl(0x00000000);
+    dev->no_of_device = htonl(0x00000001);
     strcpy(dev->path, "/sys/devices/pci0000:00/0000:00:1d.1/usb2/3-2");
     strcpy(dev->bus_id, BUS_ID);
 
     /* Not sure about these */
-    dev->busnum = 1;
-    dev->devnum = 1;
+    dev->busnum = htonl(1);
+    dev->devnum = htonl(1);
 
-    dev->speed = dev_info.speed;
-    dev->id_vendor = dev_desc->idVendor;
-    dev->id_product = dev_desc->idProduct;
-    dev->bcd_device = dev_desc->bcdDevice;
+    dev->speed = htonl(dev_info.speed);
+    dev->id_vendor = htons(dev_desc->idVendor);
+    dev->id_product = htons(dev_desc->idProduct);
+    dev->bcd_device = htons(dev_desc->bcdDevice);
     dev->b_device_class = dev_desc->bDeviceClass;
     dev->b_device_sub_class = dev_desc->bDeviceSubClass;
     dev->b_device_protocol = dev_desc->bDeviceProtocol;
@@ -221,7 +221,7 @@ void usb_class_driver_task(void *arg)
                     break;
                 }
 
-                get_op_rep_devlist_function(&dev);
+                //get_op_rep_devlist_function(&dev);
 
                 /* Starting the TCP server on Device Detection */
                 xTaskCreate(tcp_server_start, "TCP Server Start", 4096, NULL, 5, tcp_server_task);

--- a/firmware/main/src/usb_handler.c
+++ b/firmware/main/src/usb_handler.c
@@ -129,7 +129,7 @@ static void aciton_close_dev(class_driver_t *driver_obj)
 }
 
 /* Fills the dev struct with all the required information */
-esp_err_t get_op_rep_devlist(op_rep_devlist_t *dev)
+void get_op_rep_devlist_function(op_rep_devlist *dev)
 {
     dev->usbip_version = USBIP_VERSION;
     dev->reply_code = 0x0005;
@@ -156,8 +156,6 @@ esp_err_t get_op_rep_devlist(op_rep_devlist_t *dev)
     dev->b_interface_sub_class = interface_desc->bInterfaceSubClass;
     dev->b_interface_protocol = interface_desc->bInterfaceProtocol;
     dev->padding = 0x00;
-
-    return ESP_OK;
 }
 
 void usb_class_driver_task(void *arg)
@@ -192,10 +190,6 @@ void usb_class_driver_task(void *arg)
             }
             else
             {
-                /* Starting the TCP server on Device Detection */
-                xTaskCreate(tcp_server_start, "TCP Server Start", 4096, NULL, 5, tcp_server_task);
-                vTaskDelay(10);
-
                 if (driver_obj.actions & ACTION_OPEN_DEV)
                 {
                     action_open_dev(&driver_obj);
@@ -226,6 +220,12 @@ void usb_class_driver_task(void *arg)
                     /* TODO : Delete the TCP SERVER TASK and free up the resource */
                     break;
                 }
+
+                get_op_rep_devlist_function(&dev);
+
+                /* Starting the TCP server on Device Detection */
+                xTaskCreate(tcp_server_start, "TCP Server Start", 4096, NULL, 5, tcp_server_task);
+                vTaskDelay(10);
             }
         }
 

--- a/firmware/main/src/usb_handler.c
+++ b/firmware/main/src/usb_handler.c
@@ -21,8 +21,6 @@ static const usb_device_desc_t *dev_desc;
 static const usb_config_desc_t *config_desc;
 static const usb_intf_desc_t *interface_desc;
 
-SemaphoreHandle_t signaling_sem;
-
 static void client_event_cb(const usb_host_client_event_msg_t *event_msg, void *arg)
 {
     class_driver_t *driver_obj = (class_driver_t *)arg;
@@ -164,6 +162,8 @@ esp_err_t get_op_rep_devlist(op_rep_devlist_t *dev)
 
 void usb_class_driver_task(void *arg)
 {
+    SemaphoreHandle_t signaling_sem = (SemaphoreHandle_t)arg;
+    
     /* Stores all the information with regards to the USB */
     class_driver_t driver_obj;
     while (1)
@@ -238,7 +238,7 @@ void usb_class_driver_task(void *arg)
 
 void usb_host_lib_daemon_task(void *arg)
 {
-    SemaphoreHandle_t signaling_sem = xSemaphoreCreateBinary();
+    SemaphoreHandle_t signaling_sem = (SemaphoreHandle_t)arg;
     /* This will keep on looking for USB Devices */
     while (1)
     {

--- a/firmware/main/src/usbip_server.c
+++ b/firmware/main/src/usbip_server.c
@@ -13,11 +13,11 @@ TaskHandle_t *tcp_server_task = NULL;
 /* Initialises the server for USB IP */
 esp_err_t usbip_server_init()
 {
-    tcp_server_init();
+    SemaphoreHandle_t signaling_sem = xSemaphoreCreateBinary();
 
     // Starts reading the USB Devices
-    xTaskCreatePinnedToCore(usb_host_lib_daemon_task, "daemon usb task", 4096, NULL, 2, usb_daemon_task_hdl, 0);
-    xTaskCreatePinnedToCore(usb_class_driver_task, "class", 4096, NULL, 3, usb_class_driver_task_hdl, 0);
+    xTaskCreatePinnedToCore(usb_host_lib_daemon_task, "daemon usb task", 4096, (void *)signaling_sem, 2, usb_daemon_task_hdl, 0);
+    xTaskCreatePinnedToCore(usb_class_driver_task, "class", 4096, (void *)signaling_sem, 3, usb_class_driver_task_hdl, 0);
 
     ESP_LOGI(TAG, "Initialised the USB/IP server successfully");
     return ESP_OK;

--- a/firmware/main/src/usbip_server.c
+++ b/firmware/main/src/usbip_server.c
@@ -2,11 +2,29 @@
 
 #define TAG "USB/IP Server"
 
-/* Initialises the server for USB IP*/
+TaskHandle_t *tcp_server_task = NULL;
+
+/*
+1) Connect to Wifi
+2) See if USB is attached
+3) If USB is attached then start the tcp_server
+*/
+
+/* Initialises the server for USB IP */
 esp_err_t usbip_server_init()
 {
     tcp_server_init();
-    xTaskCreate(tcp_server_start, "TCP Server Start", 4096, NULL, 5, NULL);
-    ESP_LOGI(TAG, "Initialised the server successfully");
+
+    // Starts reading the USB Devices
+    xTaskCreatePinnedToCore(usb_host_lib_daemon_task, "daemon usb task", 4096, NULL, 2, usb_daemon_task_hdl, 0);
+    xTaskCreatePinnedToCore(usb_class_driver_task, "class", 4096, NULL, 3, usb_class_driver_task_hdl, 0);
+
+    ESP_LOGI(TAG, "Initialised the USB/IP server successfully");
+    return ESP_OK;
+}
+
+esp_err_t usbip_server_stop()
+{
+    /* TODO: Stop all the running tasks wrt USB/IP protocol */
     return ESP_OK;
 }


### PR DESCRIPTION
We are able to send the list of exported usb devices from esp32s2. To send data from the esp, we convert the data from host byte order to the network byte order. To do so we will use predefined functions (htons for uint16_t and htonl for uint32_t). These are defined in "arpa/inet.h"

ESP terminal
![Screenshot from 2022-06-24 00-34-16](https://user-images.githubusercontent.com/84721111/175377910-d243c1be-75f0-46e4-ad23-cf7cca84d801.png)

Client terminal
![Screenshot from 2022-06-24 00-34-54](https://user-images.githubusercontent.com/84721111/175377920-5318dd98-9cd6-452c-98f8-45da933f368a.png)

 